### PR TITLE
Fix com4j event handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 *.tli
 vc90.idb
 vc90.pdb
+**/.project
+**/.classpath
+**/.settings/
+**/target/

--- a/runtime/src/main/java/com4j/DISPNAME.java
+++ b/runtime/src/main/java/com4j/DISPNAME.java
@@ -1,0 +1,29 @@
+package com4j;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Dispatch NAME of the method.
+ *
+ * <p>
+ * Java method naming convention is to use mixed case with the first letter
+ * lowercase, with the first letter of each internal word capitalized. The com4j
+ * type library importer tool therefore camelize method names if necessary. The
+ * information of original method name is required for COM event handling to
+ * find correct Java side method. So we have to annotate that information
+ * explicitly.
+ *
+ * @author Maximilian Gerhard (mgerhard@gk-software.com)
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface DISPNAME {
+    /**
+     * DISPNAME used by {@code EventProxy}.
+     */
+    String value();
+}

--- a/tlbimp/src/main/java/com4j/tlbimp/EventInterfaceGenerator.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/EventInterfaceGenerator.java
@@ -80,6 +80,8 @@ final class EventInterfaceGenerator extends InterfaceGenerator<IDispInterfaceDec
             super.annotate(o);
             o.printf("@DISPID(%1d)",method.getDispId());
             o.println();
+            o.printf("@DISPNAME(\"%s\")", method.getName());
+            o.println();
         }
 
         @Override


### PR DESCRIPTION
This commit fixes not always working com4j event handling. There are 2 issues fixed.

First is caused by a possible camelize of method names on event interface code generation. The camelize action is compliant with Java method naming conventions but native callback into EventProxy is not aware of such renaming of methods and fails to find the DISPID by name. To solve that a new annotation DISPNAME was introduced for storing the original method name. The EventInterfaceGenerator adds this annotation now to event methods besides the existing DISPID annotation. For keeping compatibility with existing code at runtime the DISPNAME is not mandatory for EventMethods. The EventInterfaceDescriptor uses the DISPNAME value (if present) or the Java method name (previous behavior) as key to fill the methodByName map.

The second is caused by a ComException on event method invoke and an arguments Variant.convertTo error. The exception is causing the JVM to crash with a access violation. To avoid that the event method args convertTo is wrapped by a try-catch now.